### PR TITLE
Fix for issue #618

### DIFF
--- a/ixpeobssim/srcmodel/roi.py
+++ b/ixpeobssim/srcmodel/roi.py
@@ -1197,7 +1197,7 @@ class xChandraObservation(xModelComponentBase):
             return xPhotonList()
         # Compute for each CHANDRA event the relative exposure ratio and from that
         # derive, using Poisson statistics, the repetion of the event in IXPE
-        expect_repeat = irf_set.aeff(mc_energy) * duration / mc_effexp
+        expect_repeat = aeff_spline(mc_energy) * duration / mc_effexp
         # Take care of potential nan or negative values
         expect_repeat[numpy.logical_not(expect_repeat > 0.)] = 0.
         num_repeat = numpy.random.poisson(lam=expect_repeat)
@@ -1230,7 +1230,7 @@ class xChandraObservation(xModelComponentBase):
         # Rotate the polarization angle from the sky reference frame to the
         # GPD reference frame.
         pol_ang = phi_to_detphi(pol_ang, irf_set.du_id, roll_angle)
-        photon_list.fill(mc_energy, ra_pnt, dec_pnt, detx, dety, pol_deg, pol_ang)
+        photon_list.fill(mc_energy, ra, dec, detx, dety, pol_deg, pol_ang)
         # If the vignetting is enabled, apply it.
         if kwargs.get('vignetting'):
             photon_list.apply_vignetting(irf_set.vign, ra_pnt, dec_pnt)
@@ -1521,3 +1521,4 @@ class xChandraROIModel(xROIModel):
         text = 'Chandra FITS file: %s' % self.evt_file_path
         text += '\n    %s' % xROIModel.__str__(self)
         return text
+


### PR DESCRIPTION
This is fixing a issue in the end-to-end workflow when starting from a Chandra observation file. The full instrument response functions where used, as opposed to the TOW ones, to compute the exposure ratio of the two instruments when generating the photon list, which resulted in the events being effectively filtered with the GPD quantum and trigger efficiency twice.

We have also changed the content of the RA and DEC columns of the photon list files to represent the sky coordinates pre-dithering, which is more in line with what is written in the documentation. Note that this change has no practical effect on the simulation output, as we only really feed photons in (dithered) detector coordinates to ixpesim.