### PR TITLE
correction of vignetting in photon lists for periodic sources

### DIFF
--- a/ixpeobssim/srcmodel/roi.py
+++ b/ixpeobssim/srcmodel/roi.py
@@ -700,7 +700,7 @@ class xPeriodicPointSource(xPointSource):
         # Rotate the polarization angle from the sky reference frame to the
         # GPD reference frame.
         pol_ang = phi_to_detphi(pol_ang, irf_set.du_id, roll_angle)
-        photon_list.fill(energy, ra_pnt, dec_pnt, detx, dety, pol_deg, pol_ang)
+        photon_list.fill(energy, ra, dec, detx, dety, pol_deg, pol_ang)
         # If the vignetting is enabled, apply it.
         if kwargs.get('vignetting'):
             photon_list.apply_vignetting(irf_set.vign, ra_pnt, dec_pnt)


### PR DESCRIPTION
As previously done in the base class “xCelestialModelComponentBase“, the application of vignetting in photon list creation should be corrected also in the class that takes care specifically of periodic sources, “xPeriodicPointSource“.
See issue #621