### PR TITLE
Improved light curves

### DIFF
--- a/ixpeobssim/bin/xpbinview.py
+++ b/ixpeobssim/bin/xpbinview.py
@@ -64,6 +64,8 @@ def xpbinview(**kwargs):
             _kwargs['vmin'] = vmin
         if vmax is not None:
             _kwargs['vmax'] = vmax
+    elif bin_alg in ('LC',):
+        _kwargs['mjd'] = kwargs['mjd']
     viewer.plot(**_kwargs)
     if outfile is not None:
         if os.path.exists(outfile) and not kwargs.get('overwrite'):
@@ -86,7 +88,8 @@ PARSER.add_argument('--zlabel', type=str, default=None,
     help='the color map laber for count maps')
 PARSER.add_argument('--dpi', type=int, default=100,
     help='resolution of the output image in dot per inches')
-
+PARSER.add_boolean('--mjd', default=False,
+                  help='Show light curves in MJD time (as opposed to MET)')
 
 
 def main():

--- a/ixpeobssim/binning/fmt.py
+++ b/ixpeobssim/binning/fmt.py
@@ -131,10 +131,11 @@ class xBinTableHDULC(xBinTableHDUBase):
     NAME = 'RATE'
     HEADER_KEYWORDS = []
     DATA_SPECS = [
-        ('TIME'   , 'D', 's'     , 'time at the bin center'),
-        ('TIMEDEL', 'D', 's'     , 'bin size'),
-        ('COUNTS' , 'J', 'counts', 'photon counts'),
-        ('ERROR'  , 'E', 'counts', 'statistical errors')
+        ('TIME'    , 'D', 's'     , 'time at the bin center'),
+        ('TIMEDEL' , 'D', 's'     , 'bin size'),
+        ('EXPOSURE', 'D', 's'     , 'exposure in bin'),
+        ('COUNTS'  , 'D', 'counts', 'photon counts'),
+        ('ERROR'   , 'E', 'counts', 'statistical errors')
         ]
 
 


### PR DESCRIPTION
Currently, the light curves produced with xpbin/xpbinview through the LC algorithm show a rate which is just the number of counts in each bin divided by the bin width. However, this does not take into account the actual exposure in that bin. 

Here I am using the GTI table to compute the exposure in each bin, which is added to the xBinTableHDULC files in the new EXPOSURE column. In order to account for the dead time I am using the DEADC value to scale the EXPOSURE --- this is an approximation valid only if the dead time fraction is small or if the rate is approximately constant, which is true for 99% of our use cases. Note that an event-by-event correction of the dead time would require the LIVETIME column, which only exists in LV1 files. 

When summing xBinTableHDULC files generated for different DUs, the EXPOSURE column is computed by taking the average of the individual exposures and the COUNTS are combined in such a way that the final rate is exactly the sum of the individual rates. Note that this implies switching from integers to floating point numbers for the COUNTS column, in order to prevent rounding errors.

I have also added support for MJD format in light curve plotting, which I think is handy when comparing different experiments.
The conversion between METs and MJD is performed in xpbinview; however, we may consider doing this in xpbin, so that the time column is directly saved in MJD format. This may be more useful if the user want to further manipulate the data without passing from xpbinview.