### PR TITLE
Barytime fix

### DIFF
--- a/ixpeobssim/bin/xpphase.py
+++ b/ixpeobssim/bin/xpphase.py
@@ -115,7 +115,7 @@ def xpphase(**kwargs):
 
 
         logger.info('Calculating pulsar phase...')
-        phase = eph.fold(time_, evt_header['TSTART'], kwargs.get('phi0'))
+        phase = eph.fold(time_, kwargs.get('met0'), kwargs.get('phi0'))
         logger.info('Creating phase column...')
         col_ = fits.Column(name='PHASE', array=phase, format='E')
         new_hdu = fits.BinTableHDU.from_columns(evt_hdu.data.columns + col_, header=evt_header)

--- a/ixpeobssim/bin/xpphase.py
+++ b/ixpeobssim/bin/xpphase.py
@@ -101,12 +101,18 @@ def xpphase(**kwargs):
             logger.info('Output file %s already exists.', outfile)
             logger.info('Remove the file or set "overwrite = True" to overwrite it.')
             continue
-
         logger.info('Opening "%s"...', file_path)
         hdu = fits.open(file_path)
         evt_hdu = hdu['EVENTS']
-        time_ = evt_hdu.data['TIME']
+        # Load time from BARYTIME columns if exists, else default to TIME
+        if 'BARYTIME' in evt_hdu.data.names:
+            time_ = evt_hdu.data['BARYTIME']
+            logger.info('Loading time column from BARYTIME...')
+        else:
+            time_ = evt_hdu.data['TIME']
+            logger.info('BARYTIME not found, defaulting to TIME column')
         evt_header = evt_hdu.header
+
 
         logger.info('Calculating pulsar phase...')
         phase = eph.fold(time_, evt_header['TSTART'], kwargs.get('phi0'))


### PR DESCRIPTION
A fix and a feature:

Feature
If the input file has a BARYTIME column that is used by default, otherwise TIME is used as previously

Fix
The met0 is used for phase folding instead of TSTART