### PR TITLE
More fixes to deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,21 +20,23 @@ jobs:
         name: Publish to PyPi
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         runs-on: ubuntu-latest
+        permissions:
+          id-token: write        
         steps:
             - name: Checkout source
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Set up Python 3.9
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.9
             - name: Install dependencies
               run: |
-                  python -m pip install --upgrade pip wheel setuptools
+                  python -m pip install --upgrade pip wheel setuptools packaging
             - name: Build package
               run: |
                   python setup.py sdist bdist_wheel
             - name: Publish
-              uses: pypa/gh-action-pypi-publish@v1.1.0
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}
@@ -45,8 +47,8 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: 3.9
             - name: Install dependencies
@@ -57,7 +59,7 @@ jobs:
                   python -m pip install twine
             - name: Build package
               run: |
-                python setup.py sdist
+                python setup.py sdist bdist_wheel
 
             - name: List result
               run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         runs-on: ubuntu-latest
         permissions:
-          id-token: write        
+          id-token: write
         steps:
             - name: Checkout source
               uses: actions/checkout@v4
@@ -38,8 +38,6 @@ jobs:
             - name: Publish
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
-                  user: __token__
-                  password: ${{ secrets.PYPI_API_TOKEN }}
                   skip-existing: true
 
     test-publish-pypi:


### PR DESCRIPTION
I've updated the package versions and switched to the trusted publishing flow (I've also updated the pypi configuration). I'm still not entirely sure what caused the error reported on issue #740, but these changes should hopefully fix it. The only way to test this, unfortunately, is to try releasing a new build. This could also be a development version, labeled `31.1.0.dev1`. I'd be happy to give it a try if you want.